### PR TITLE
Fix caption color of first render with dark theme

### DIFF
--- a/streamlit_image_select/frontend/src/index.tsx
+++ b/streamlit_image_select/frontend/src/index.tsx
@@ -14,22 +14,6 @@ function onRender(event: Event): void {
   // Get the RenderData from the event
   const data = (event as CustomEvent<RenderData>).detail
 
-  if (data.theme) {
-    labelDiv.style.font = data.theme.font
-    labelDiv.style.color = data.theme.textColor
-    if (data.theme.base === "dark") {
-      document.body.querySelectorAll(".box, .caption").forEach((el) => {
-        el.classList.add("dark")
-      })
-    } else {
-      document.body.querySelectorAll(".box, .caption").forEach((el) => {
-        el.classList.remove("dark")
-      })
-    }
-
-    // TODO: Gray out the component if it's disabled.
-  }
-
   label.textContent = data.args["label"]
   let images = data.args["images"]
   let captions = data.args["captions"]
@@ -70,6 +54,22 @@ function onRender(event: Event): void {
         img.classList.add("selected")
       }
     })
+  }
+
+  if (data.theme) {
+    labelDiv.style.font = data.theme.font
+    labelDiv.style.color = data.theme.textColor
+    if (data.theme.base === "dark") {
+      document.body.querySelectorAll(".box, .caption").forEach((el) => {
+        el.classList.add("dark")
+      })
+    } else {
+      document.body.querySelectorAll(".box, .caption").forEach((el) => {
+        el.classList.remove("dark")
+      })
+    }
+
+    // TODO: Gray out the component if it's disabled.
   }
 
   // We tell Streamlit to update our frameHeight after each render event, in


### PR DESCRIPTION
Move dark theme handling code lower, to affect caption variable. Otherwise on the first render of the app with dark theme, the caption color is almost not visible as it uses the light theme color.