### PR TITLE
Enable selection of multiple images

### DIFF
--- a/demo/streamlit_app.py
+++ b/demo/streamlit_app.py
@@ -50,7 +50,7 @@ arrays. You can also add captions (optional)!
 with st.echo():
     from streamlit_image_select import image_select
 
-    img = image_select(
+    imgs = image_select(
         label="Select a cat",
         images=[
             "images/cat1.jpeg",
@@ -59,6 +59,7 @@ with st.echo():
             np.array(Image.open("images/cat4.jpeg")),
         ],
         captions=["A cat", "Another cat", "Oh look, a cat!", "Guess what, a cat..."],
+        index=None
     )
 
 # st.file_uploader("Or upload your own cat!", type=["jpg", "jpeg", "png"])
@@ -71,40 +72,43 @@ st.info(
     icon="↔️",
 )
 
-if isinstance(img, np.ndarray):
-    position = (55, 15)
-elif isinstance(img, Image.Image):
-    position = (30, 90)
-elif img == "images/cat1.jpeg":
-    position = (65, 70)
-elif (
-    img
-    == "https://bagongkia.github.io/react-image-picker/0759b6e526e3c6d72569894e58329d89.jpg"
-):
-    position = (15, 70)
-else:
-    position = (100, 100)
-
-# if isinstance(img, np.ndarray):
-#     position = (60, -15)
-# elif isinstance(img, Image.Image):
-#     position = (40, 60)
-# elif img == "images/cat1.jpeg":
-#     position = (65, 35)
-# elif img == "https://bagongkia.github.io/react-image-picker/0759b6e526e3c6d72569894e58329d89.jpg":
-#     position = (20, 40)
-# else:
-#     position = (100, 100)
-
 """
 ## Step 3: Use the return value
 The return value is just the same object you passed into the list of images above. 
 Note that you can pipe it directly into `st.image` (or add some cool sunglasses 😎). 
 """
+if imgs is None:
+    st.warning("No image selected!")
+else:
+    for img in imgs:
+        if isinstance(img, np.ndarray):
+            position = (55, 15)
+        elif isinstance(img, Image.Image):
+            position = (30, 90)
+        elif img == "images/cat1.jpeg":
+            position = (65, 70)
+        elif (
+            img
+            == "https://bagongkia.github.io/react-image-picker/0759b6e526e3c6d72569894e58329d89.jpg"
+        ):
+            position = (15, 70)
+        else:
+            position = (100, 100)
 
-with st.echo():
-    st.write(str(img)[:100])
-    st.image(add_sunglasses(img, position))
+        # if isinstance(img, np.ndarray):
+        #     position = (60, -15)
+        # elif isinstance(img, Image.Image):
+        #     position = (40, 60)
+        # elif img == "images/cat1.jpeg":
+        #     position = (65, 35)
+        # elif img == "https://bagongkia.github.io/react-image-picker/0759b6e526e3c6d72569894e58329d89.jpg":
+        #     position = (20, 40)
+        # else:
+        #     position = (100, 100)
+
+        with st.echo():
+            st.write(str(img)[:100])
+            st.image(add_sunglasses(img, position))
 
 st.info(
     'Want the index of the selected image instead? Set `return_value="index"`.',

--- a/demo/streamlit_app.py
+++ b/demo/streamlit_app.py
@@ -59,7 +59,7 @@ with st.echo():
             np.array(Image.open("images/cat4.jpeg")),
         ],
         captions=["A cat", "Another cat", "Oh look, a cat!", "Guess what, a cat..."],
-        index=None
+        indices=None
     )
 
 # st.file_uploader("Or upload your own cat!", type=["jpg", "jpeg", "png"])
@@ -77,7 +77,7 @@ st.info(
 The return value is just the same object you passed into the list of images above. 
 Note that you can pipe it directly into `st.image` (or add some cool sunglasses 😎). 
 """
-if imgs is None:
+if not imgs:
     st.warning("No image selected!")
 else:
     for img in imgs:

--- a/streamlit_image_select/__init__.py
+++ b/streamlit_image_select/__init__.py
@@ -39,7 +39,7 @@ def image_select(
     label: str,
     images: list,
     captions: list = None,
-    index: int = 0,
+    indices: list = None,
     *,
     use_container_width: bool = True,
     return_value: str = "original",
@@ -53,8 +53,8 @@ def image_select(
             files, URLs, PIL images, and numpy arrays.
         captions (list of str): The captions to show below the images. Defaults to
             None, in which case no captions are shown.
-        index (int, optional): The index of the image that is selected by default.
-            Defaults to 0.
+        indices (list of int, optional): The indices of the images that are selected by default.
+            Defaults to None.
         use_container_width (bool, optional): Whether to stretch the images to the
             width of the surrounding container. Defaults to True.
         return_value ("original" or "index", optional): Whether to return the
@@ -75,11 +75,20 @@ def image_select(
             "The number of images and captions must be equal but `captions` has "
             f"{len(captions)} elements and `images` has {len(images)} elements."
         )
-    if index is not None and index >= len(images):
+    if indices is None:
+        indices = []
+    if isinstance(indices, int):
+        indices = [indices]
+    if not isinstance(indices, list):
         raise ValueError(
-            f"`index` must be smaller than the number of images ({len(images)}) "
-            f"but it is {index}."
+            f"`indices` must be a list of integers but it is {type(indices)}."
         )
+    for i, index in enumerate(indices):
+        if index >= len(images):
+            raise ValueError(
+                f"Image index at {i} must be smaller than the number of images ({len(images)}) "
+                f"but it is {index}."
+            )
 
     # Encode local images/numpy arrays/PIL images to base64.
     encoded_images = []
@@ -96,15 +105,14 @@ def image_select(
         label=label,
         images=encoded_images,
         captions=captions,
-        index=index,
+        indices=indices,
         use_container_width=use_container_width,
         key=key,
-        default=index,
+        default=indices
     )
 
     # The frontend component returns the index of the selected image but we want to
     # return the actual image.
-    print(f'{component_values=}')
     if return_value == "original":
         return [images[component_value] for component_value in component_values]
     elif return_value == "index":

--- a/streamlit_image_select/__init__.py
+++ b/streamlit_image_select/__init__.py
@@ -8,7 +8,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 from PIL import Image
 
-_RELEASE = False
+_RELEASE = True
 
 if not _RELEASE:
     _component_func = components.declare_component(

--- a/streamlit_image_select/__init__.py
+++ b/streamlit_image_select/__init__.py
@@ -8,7 +8,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 from PIL import Image
 
-_RELEASE = True
+_RELEASE = False
 
 if not _RELEASE:
     _component_func = components.declare_component(
@@ -75,7 +75,7 @@ def image_select(
             "The number of images and captions must be equal but `captions` has "
             f"{len(captions)} elements and `images` has {len(images)} elements."
         )
-    if index >= len(images):
+    if index is not None and index >= len(images):
         raise ValueError(
             f"`index` must be smaller than the number of images ({len(images)}) "
             f"but it is {index}."
@@ -92,7 +92,7 @@ def image_select(
             encoded_images.append(img)
 
     # Pass everything to the frontend.
-    component_value = _component_func(
+    component_values = _component_func(
         label=label,
         images=encoded_images,
         captions=captions,
@@ -104,10 +104,11 @@ def image_select(
 
     # The frontend component returns the index of the selected image but we want to
     # return the actual image.
+    print(f'{component_values=}')
     if return_value == "original":
-        return images[component_value]
+        return [images[component_value] for component_value in component_values]
     elif return_value == "index":
-        return component_value
+        return component_values
     else:
         raise ValueError(
             "`return_value` must be either 'original' or 'index' "

--- a/streamlit_image_select/frontend/src/index.tsx
+++ b/streamlit_image_select/frontend/src/index.tsx
@@ -4,6 +4,7 @@ const labelDiv = document.body.appendChild(document.createElement("label"))
 const label = labelDiv.appendChild(document.createTextNode(""))
 const container = document.body.appendChild(document.createElement("div"))
 container.classList.add("container")
+const selected_component_values: number[] = []
 
 /**
  * The component's render function. This will be called immediately after
@@ -56,18 +57,33 @@ function onRender(event: Event): void {
         caption.textContent = captions[i]
       }
 
-      if (i === data.args["index"]) {
+      if (data.args["index"] !== null && i === data.args["index"]) {
         box.classList.add("selected")
         img.classList.add("selected")
+        selected_component_values.push(i)
+      }else{
+        box.classList.remove("selected")
+        img.classList.remove("selected")
+        selected_component_values.splice(selected_component_values.indexOf(i), 1)
       }
+      Streamlit.setComponentValue(selected_component_values)
 
       img.onclick = function () {
-        container.querySelectorAll(".selected").forEach((el) => {
-          el.classList.remove("selected")
-        })
-        Streamlit.setComponentValue(i)
-        box.classList.add("selected")
-        img.classList.add("selected")
+        // To disable multi-select, uncomment the following lines.
+        // container.querySelectorAll(".selected").forEach((el) => {
+        //   el.classList.remove("selected")
+        // })
+        // check if the image is already selected
+        if (box.classList.contains("selected")) {
+          selected_component_values.splice(selected_component_values.indexOf(i), 1)
+          box.classList.remove("selected")
+          img.classList.remove("selected")
+        } else {
+          selected_component_values.push(i)
+          box.classList.add("selected")
+          img.classList.add("selected")
+        }
+        Streamlit.setComponentValue(selected_component_values)
       }
     })
   }

--- a/streamlit_image_select/frontend/src/index.tsx
+++ b/streamlit_image_select/frontend/src/index.tsx
@@ -65,11 +65,7 @@ function onRender(event: Event): void {
       }
 
       img.onclick = function () {
-        // To disable multi-select, uncomment the following lines.
-        // container.querySelectorAll(".selected").forEach((el) => {
-        //   el.classList.remove("selected")
-        // })
-        // check if the image is already selected
+        // check if the image is already selected, then un-select it and remove it from the array
         if (box.classList.contains("selected")) {
           selected_component_values.splice(selected_component_values.indexOf(i), 1)
           box.classList.remove("selected")

--- a/streamlit_image_select/frontend/src/index.tsx
+++ b/streamlit_image_select/frontend/src/index.tsx
@@ -61,12 +61,7 @@ function onRender(event: Event): void {
         box.classList.add("selected")
         img.classList.add("selected")
         selected_component_values.push(i)
-      }else{
-        box.classList.remove("selected")
-        img.classList.remove("selected")
-        selected_component_values.splice(selected_component_values.indexOf(i), 1)
       }
-      Streamlit.setComponentValue(selected_component_values)
 
       img.onclick = function () {
         // To disable multi-select, uncomment the following lines.
@@ -83,9 +78,12 @@ function onRender(event: Event): void {
           box.classList.add("selected")
           img.classList.add("selected")
         }
+        selected_component_values.sort()
         Streamlit.setComponentValue(selected_component_values)
       }
     })
+    // return selected_component_values
+    Streamlit.setComponentValue(selected_component_values)
   }
 
   // We tell Streamlit to update our frameHeight after each render event, in

--- a/streamlit_image_select/frontend/src/index.tsx
+++ b/streamlit_image_select/frontend/src/index.tsx
@@ -57,7 +57,8 @@ function onRender(event: Event): void {
         caption.textContent = captions[i]
       }
 
-      if (data.args["index"] !== null && i === data.args["index"]) {
+      // check if i is in the index array
+      if (data.args["indices"] !== undefined && data.args["indices"].includes(i)) {
         box.classList.add("selected")
         img.classList.add("selected")
         selected_component_values.push(i)


### PR DESCRIPTION
Changes:
- select multiple images by default: `index` arg became `indices`
- by default no image is selected
- `image_select` return list of images instead of a single image, subsequently, the list is empty when no image is selected

TODO: 
- [ ] update changelog in Readme.md

fixes #1 